### PR TITLE
fix: fetch bookmark IDs on boot so icons reflect saved state on any page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ import { getQueryParamValue } from '@/utils/urlsUtils';
 import { getUserAndSession } from '@/utils/auth';
 
 const { getSourcesList, getInfoPerCorpus } = useSourcesStore();
-const { fetchBookmarkIds } = useBookmarksStore();
+const { getBookmarks } = useBookmarksStore();
 const fetchError = ref(false);
 
 async function initCalls() {
@@ -21,7 +21,7 @@ async function initCalls() {
       getInfoPerCorpus(),
       getSourcesList(),
       getUserAndSession(getQueryParamValue('referer') || ''),
-      fetchBookmarkIds()
+      getBookmarks()
     ]);
   } catch (err) {
     console.error(err);

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,10 +7,12 @@ import FooterComponent from '@/components/FooterComponent.vue';
 import AppLayout from '@/components/AppLayout.vue';
 import WelcomeModal from '@/components/modals/WelcomeModal.vue';
 import { useSourcesStore } from '@/stores/sources';
+import { useBookmarksStore } from '@/stores/bookmarks';
 import { getQueryParamValue } from '@/utils/urlsUtils';
 import { getUserAndSession } from '@/utils/auth';
 
 const { getSourcesList, getInfoPerCorpus } = useSourcesStore();
+const { fetchBookmarkIds } = useBookmarksStore();
 const fetchError = ref(false);
 
 async function initCalls() {
@@ -18,7 +20,8 @@ async function initCalls() {
     await Promise.all([
       getInfoPerCorpus(),
       getSourcesList(),
-      getUserAndSession(getQueryParamValue('referer') || '')
+      getUserAndSession(getQueryParamValue('referer') || ''),
+      fetchBookmarkIds()
     ]);
   } catch (err) {
     console.error(err);

--- a/src/stores/bookmarks.ts
+++ b/src/stores/bookmarks.ts
@@ -5,8 +5,7 @@ import {
   postBookmark,
   deleteBookmark,
   getBookmarks as getAllBookmarks,
-  deleteAllBookmarks,
-  baseGetAxios
+  deleteAllBookmarks
 } from '@/utils/fetch';
 
 export const useBookmarksStore = defineStore('bookmarks', () => {
@@ -34,17 +33,6 @@ export const useBookmarksStore = defineStore('bookmarks', () => {
     idsBookmarked.value = idsBookmarked.value.filter((id) => id !== sourceId);
     await deleteBookmark(sourceId);
     hasChanged.value = true;
-  };
-
-  const fetchBookmarkIds = async () => {
-    try {
-      const result = await baseGetAxios('/user/bookmarks');
-      idsBookmarked.value = (result.bookmarks ?? []).map(
-        (b: { document_id: string }) => b.document_id
-      );
-    } catch (error) {
-      console.error('Failed to fetch bookmark IDs:', error);
-    }
   };
 
   const getBookmarks = async () => {
@@ -85,7 +73,6 @@ export const useBookmarksStore = defineStore('bookmarks', () => {
     sourcesBookmarked,
     addBookmark,
     removeBookmark,
-    fetchBookmarkIds,
     getBookmarks,
     resetBookmarks,
     toggleBookmark,

--- a/src/stores/bookmarks.ts
+++ b/src/stores/bookmarks.ts
@@ -5,7 +5,8 @@ import {
   postBookmark,
   deleteBookmark,
   getBookmarks as getAllBookmarks,
-  deleteAllBookmarks
+  deleteAllBookmarks,
+  baseGetAxios
 } from '@/utils/fetch';
 
 export const useBookmarksStore = defineStore('bookmarks', () => {
@@ -33,6 +34,17 @@ export const useBookmarksStore = defineStore('bookmarks', () => {
     idsBookmarked.value = idsBookmarked.value.filter((id) => id !== sourceId);
     await deleteBookmark(sourceId);
     hasChanged.value = true;
+  };
+
+  const fetchBookmarkIds = async () => {
+    try {
+      const result = await baseGetAxios('/user/bookmarks');
+      idsBookmarked.value = (result.bookmarks ?? []).map(
+        (b: { document_id: string }) => b.document_id
+      );
+    } catch (error) {
+      console.error('Failed to fetch bookmark IDs:', error);
+    }
   };
 
   const getBookmarks = async () => {
@@ -73,6 +85,7 @@ export const useBookmarksStore = defineStore('bookmarks', () => {
     sourcesBookmarked,
     addBookmark,
     removeBookmark,
+    fetchBookmarkIds,
     getBookmarks,
     resetBookmarks,
     toggleBookmark,


### PR DESCRIPTION
## Summary
- Adds `fetchBookmarkIds()` to the bookmarks store — calls `GET /user/bookmarks`, extracts IDs only (no document payloads), and sets `idsBookmarked`
- Calls it from `App.vue`'s boot sequence in parallel with existing init calls, so it costs no extra time

## Why
`idsBookmarked` was always empty on page load until the user visited the bookmarks tab. This caused already-saved documents to appear un-bookmarked on the search/chat pages, and clicking the bookmark icon would try to add a duplicate instead of removing.

## Test plan
- [ ] Bookmark some documents, then hard-refresh while on the search page — saved docs should show filled bookmark icons immediately
- [ ] Clicking a filled icon should remove the bookmark (not re-add it)
- [ ] Visiting the bookmarks tab still loads full document data as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)