### PR TITLE
Add "export bibliography" button

### DIFF
--- a/src/components/SourcesListComponent.vue
+++ b/src/components/SourcesListComponent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue';
 import type { Document } from '@/types';
 import Card from '@/components/CardComponent.vue';
 import SimpleCard from '@/components/CardSimpleComponent.vue';
@@ -8,6 +9,7 @@ import { useMetricsStore } from '@/stores/metrics';
 import { useBookmarksStore } from '@/stores/bookmarks';
 import ModalWrapper from '@/components/ModalWrapper.vue';
 import i18n from '@/localisation/i18n';
+import { exportBibliography } from '@/utils/fetch';
 
 const sourcesStore = useSourcesStore();
 const metricsStore = useMetricsStore();
@@ -33,6 +35,49 @@ const Cards = {
 };
 
 const ChosenCard = Cards[props.cardType || 'default'];
+
+const isExportingBibliography = ref(false);
+
+const documentIds = computed(() => {
+  const ids = props.sourcesList
+    .map((doc) => doc.payload.document_id)
+    .filter((id): id is string => Boolean(id));
+
+  return [...new Set(ids)];
+});
+
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.URL.revokeObjectURL(objectUrl);
+};
+
+const handleBibliographyExport = async () => {
+  if (!documentIds.value.length || isExportingBibliography.value) return;
+
+  isExportingBibliography.value = true;
+
+  try {
+    const response = await exportBibliography(documentIds.value);
+    const fileName = "welearn_bilbiography_export.ris";
+    const fileBlob =
+      response.data instanceof Blob
+        ? response.data
+        : new Blob([response.data], { type: response.headers['content-type'] });
+
+    downloadBlob(fileBlob, fileName);
+  } catch (error) {
+    console.error('Unable to export bibliography:', error);
+  } finally {
+    isExportingBibliography.value = false;
+  }
+};
 </script>
 <template>
   <div class="sources-list">
@@ -54,6 +99,20 @@ const ChosenCard = Cards[props.cardType || 'default'];
 
     <div v-if="sourcesList?.length">
       <a id="sourcesAnchor"></a>
+
+      <div class="sources-list__actions">
+        <button
+          class="button is-small is-primary"
+          :disabled="isExportingBibliography || !documentIds.length"
+          @click="handleBibliographyExport"
+        >
+          {{
+            isExportingBibliography
+              ? $t('sourcesList.exportingBibliography')
+              : $t('sourcesList.exportBibliography')
+          }}
+        </button>
+      </div>
 
       <ChosenCard
         :category="sourcesStore.sourceCategoryMap[doc.payload.document_corpus]"
@@ -114,5 +173,11 @@ const ChosenCard = Cards[props.cardType || 'default'];
   height: auto;
   overflow-y: scroll;
   padding: 0.5rem 0.5rem;
+}
+
+.sources-list__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
 }
 </style>

--- a/src/localisation/en.ts
+++ b/src/localisation/en.ts
@@ -325,7 +325,9 @@ export const en = {
   sources: 'Sources',
   sourcesList: {
     fetching: 'Searching across {docs_nb} documents...',
-    formulatingAnswer: 'Preparing your answer...'
+    formulatingAnswer: 'Preparing your answer...',
+    exportBibliography: 'Export bibliography',
+    exportingBibliography: 'Exporting...'
   },
   terms: 'Privacy Policy',
   giveFeedback: 'Feedback Form',

--- a/src/localisation/fr.ts
+++ b/src/localisation/fr.ts
@@ -328,7 +328,9 @@ export const fr = {
   sources: 'Sources',
   sourcesList: {
     fetching: 'Recherche parmi {docs_nb} documents...',
-    formulatingAnswer: 'Préparation de votre réponse...'
+    formulatingAnswer: 'Préparation de votre réponse...',
+    exportBibliography: 'Exporter la bibliographie',
+    exportingBibliography: 'Export en cours...'
   },
   terms: 'Politique de confidentialité',
   giveFeedback: 'Formulaire de retour',

--- a/src/utils/__tests__/fetch.spec.ts
+++ b/src/utils/__tests__/fetch.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { baseGetAxios, basePostAxios, API_BASE, WL_API_KEY } from '../fetch';
+import { baseGetAxios, basePostAxios, API_BASE, WL_API_KEY, exportBibliography } from '../fetch';
 
 const mockResolved = {
   status: 200
@@ -73,6 +73,32 @@ describe('fetch', () => {
       it('should throw an error', async () => {
         await expect(baseGetAxios('/endpoint')).rejects.toThrow('Error fetching data');
       });
+    });
+  });
+
+  describe('exportBibliography', () => {
+    beforeEach(() => {
+      vi.spyOn(axios, 'post').mockResolvedValue(mockResolved);
+    });
+
+    it('should send documents_ids to the bibliography endpoint', async () => {
+      const documentsIds = ['a4a8911f-007f-4353-a362-a25b6673f738', 'a4eeeba0-a965-4edf-8fe7-ee4c7fa01338'];
+
+      await exportBibliography(documentsIds);
+
+      expect(axios.post).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/bibliography/export_bibliography`,
+        { documents_ids: documentsIds },
+        {
+          headers: { 'X-API-Key': WL_API_KEY, 'X-Session-Id': '' },
+          responseType: 'blob',
+          withCredentials: true
+        }
+      );
+    });
+
+    it('should throw when documentsIds is empty', async () => {
+      await expect(exportBibliography([])).rejects.toThrow('No document ids provided');
     });
   });
 });

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -190,3 +190,14 @@ export const getBookmarks = async () => {
   const docsPayloads = await basePostAxios('/search/documents/by_ids', ids);
   return docsPayloads;
 };
+
+export const exportBibliography = async (documentsIds: string[]) => {
+  if (!documentsIds.length) throw new Error('No document ids provided');
+
+  return basePostAxios(
+    '/bibliography/export_bibliography',
+    { documents_ids: documentsIds },
+    { responseType: 'blob' }
+  );
+};
+


### PR DESCRIPTION
This pull request adds a new "Export Bibliography" feature to the sources list, allowing users to download the bibliography for the displayed sources as a `.ris` file. It introduces the necessary UI, logic, API utility, and tests to support this feature, as well as updates to English and French translations.

**Export Bibliography feature:**

* Added an "Export Bibliography" button to the sources list UI in `SourcesListComponent.vue`, including loading state handling and disabling when no documents are available. [[1]](diffhunk://#diff-eedbfc9b5f11e7aa57b3a527fdb4a81cccfb131721016c6e5601ce54b3f65babR103-R116) [[2]](diffhunk://#diff-eedbfc9b5f11e7aa57b3a527fdb4a81cccfb131721016c6e5601ce54b3f65babR38-R80)
* Implemented the `exportBibliography` utility function in `fetch.ts` to POST the selected document IDs and return the bibliography as a blob.
* Added logic to handle file download in the browser and error handling for the export process in `SourcesListComponent.vue`.
* Created unit tests for `exportBibliography` to ensure correct API usage and error handling for empty input.

**Localization:**

* Updated English (`en.ts`) and French (`fr.ts`) translations with new strings for the export button and its loading state. [[1]](diffhunk://#diff-1f75a06c0a5b7986673c882b79a0d7592584351ff4c7f3a65aeeebf521f3e39fL328-R330) [[2]](diffhunk://#diff-a0531764e7d25766c7ca9ab96448646ec33fad5c2ddfa305932d0947f97c8901L331-R333)